### PR TITLE
[feat/friend] feat: follow, unfollow

### DIFF
--- a/src/main/java/cos/peerna/PeernaApplication.java
+++ b/src/main/java/cos/peerna/PeernaApplication.java
@@ -5,6 +5,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 //import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -16,6 +17,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"cos.peerna.repository"})
 @EnableRedisRepositories
+@EnableJpaAuditing
 public class PeernaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/cos/peerna/controller/RoomController.java
+++ b/src/main/java/cos/peerna/controller/RoomController.java
@@ -1,13 +1,10 @@
 package cos.peerna.controller;
 
 import cos.peerna.controller.dto.DetailHistoryResponseDto;
-import cos.peerna.controller.dto.MatchedUserDto;
 import cos.peerna.controller.dto.RoomResponseDto;
 import cos.peerna.domain.*;
-import cos.peerna.repository.ConnectedUserRepository;
 import cos.peerna.repository.HistoryRepository;
 import cos.peerna.repository.RoomRepository;
-import cos.peerna.repository.UserRepository;
 import cos.peerna.security.LoginUser;
 import cos.peerna.security.dto.SessionUser;
 import cos.peerna.service.HistoryService;

--- a/src/main/java/cos/peerna/controller/UserController.java
+++ b/src/main/java/cos/peerna/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("No User Data");
         }
-        userService.follow(user, followeeId);
+        userService.follow(user.getId(), followeeId);
         return ResponseEntity.ok()
                 .body("success");
     }
@@ -79,7 +79,7 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("No User Data");
         }
-        userService.unfollow(user, followeeId);
+        userService.unfollow(user.getId(), followeeId);
         return ResponseEntity.ok()
                 .body("success");
     }

--- a/src/main/java/cos/peerna/controller/UserController.java
+++ b/src/main/java/cos/peerna/controller/UserController.java
@@ -62,15 +62,26 @@ public class UserController {
                 .body("success");
     }
 
-    @GetMapping("/oauth2-login-fail")
-    public void oauth2LoginFail(HttpServletResponse response) {
-        String redirectUri = "http://ec2-43-200-47-43.ap-northeast-2.compute.amazonaws.com:3000/";
-
-        try {
-            response.sendRedirect(redirectUri);
-        } catch (IOException e) {
-            e.printStackTrace();
+    @PostMapping("/api/users/follow")
+    public ResponseEntity<String> follow(@LoginUser SessionUser user, @RequestParam Long followeeId) {
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("No User Data");
         }
+        userService.follow(user, followeeId);
+        return ResponseEntity.ok()
+                .body("success");
+    }
+
+    @DeleteMapping("/api/users/follow")
+    public ResponseEntity<String> unfollow(@LoginUser SessionUser user, @RequestParam Long followeeId) {
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("No User Data");
+        }
+        userService.unfollow(user, followeeId);
+        return ResponseEntity.ok()
+                .body("success");
     }
 
     // 테스트 or 디버그 용 회원가입

--- a/src/main/java/cos/peerna/controller/dto/RoomResponseDto.java
+++ b/src/main/java/cos/peerna/controller/dto/RoomResponseDto.java
@@ -10,6 +10,6 @@ public class RoomResponseDto {
     private Integer roomId;
     private Long    historyId;
     private Problem problem;
-    private MatchedUserDto peer;
+    private UserProfileDto peer;
 
 }

--- a/src/main/java/cos/peerna/controller/dto/UserProfileDto.java
+++ b/src/main/java/cos/peerna/controller/dto/UserProfileDto.java
@@ -1,16 +1,15 @@
 package cos.peerna.controller.dto;
 
 import cos.peerna.domain.User;
-import lombok.Builder;
 import lombok.Data;
 
 @Data
-public class MatchedUserDto {
+public class UserProfileDto {
     private Long id;
     private String name;
     private String imageUrl;
 
-    public MatchedUserDto (User peer) {
+    public UserProfileDto(User peer) {
         this.id = peer.getId();
         this.name = peer.getName();
         this.imageUrl = peer.getImageUrl();

--- a/src/main/java/cos/peerna/controller/dto/data/NotificationData.java
+++ b/src/main/java/cos/peerna/controller/dto/data/NotificationData.java
@@ -1,5 +1,6 @@
 package cos.peerna.controller.dto.data;
 
+import cos.peerna.controller.dto.UserProfileDto;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,7 +10,9 @@ import java.time.LocalDate;
 @Builder
 public class NotificationData {
 	private Long        notificationId;
+	private String		type;
 	private String      answer;
+	private UserProfileDto sender;
 	private String      msg;
 	private LocalDate   time;
 }

--- a/src/main/java/cos/peerna/domain/BaseTimeEntity.java
+++ b/src/main/java/cos/peerna/domain/BaseTimeEntity.java
@@ -1,0 +1,31 @@
+package cos.peerna.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    public abstract void delete();
+
+    public void update() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/cos/peerna/domain/Follow.java
+++ b/src/main/java/cos/peerna/domain/Follow.java
@@ -1,0 +1,31 @@
+package cos.peerna.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Follow extends BaseTimeEntity {
+    @ManyToOne(fetch= FetchType.LAZY)
+    @JoinColumn
+    private User follower;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn
+    private User followee;
+
+    public Follow(User follower, User followee) {
+        this.follower = follower;
+        this.followee = followee;
+        follower.getFollowings().add(this);
+        followee.getFollowers().add(this);
+    }
+
+    @Override
+    public void delete() {
+        follower.getFollowings().remove(this);
+        followee.getFollowers().remove(this);
+    }
+}

--- a/src/main/java/cos/peerna/domain/Notification.java
+++ b/src/main/java/cos/peerna/domain/Notification.java
@@ -35,17 +35,6 @@ public class Notification {
 
 	private LocalDate time;
 
-	public static Notification createNotification(User user, Reply reply, NotificationType type, String msg) {
-		Notification notification = new Notification();
-		notification.user = user;
-		notification.reply = reply;
-		notification.type = type;
-		notification.msg = msg;
-		notification.time = LocalDate.now();
-
-		return notification;
-	}
-
 	@Builder
 	public Notification(String msg, User user, Reply reply, User follower, NotificationType type) {
 		this.msg = msg;

--- a/src/main/java/cos/peerna/domain/Notification.java
+++ b/src/main/java/cos/peerna/domain/Notification.java
@@ -1,12 +1,16 @@
 package cos.peerna.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification {
 
 	@Id @GeneratedValue
@@ -21,6 +25,10 @@ public class Notification {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "reply_id", nullable = true)
 	private Reply reply;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(nullable = true)
+	private User follower;
 
 	@Enumerated(EnumType.STRING)
 	private NotificationType type;
@@ -38,19 +46,32 @@ public class Notification {
 		return notification;
 	}
 
+	@Builder
+	public Notification(String msg, User user, Reply reply, User follower, NotificationType type) {
+		this.msg = msg;
+		this.user = user;
+		this.reply = reply;
+		this.follower = follower;
+		this.type = type;
+		this.time = LocalDate.now();
+	}
+
 	public static void acceptNotification(Notification notification) {
 		if (notification.type.equals(NotificationType.PULL_REQ)) {
 			notification.type = NotificationType.PULL_REQ_ACC;
 			notification.msg = "Pull-Request가 수락되었습니다.";
 		}
-		else if (notification.type.equals(NotificationType.FRIEND)) {
-			notification.type = NotificationType.FRIEND_ACC;
-			notification.msg = "친구 추가를 수락하였습니다.";
+		else if (notification.type.equals(NotificationType.FOLLOW)) {
+			notification.type = NotificationType.FOLLOW_EACH;
 		}
 		notification.time = LocalDate.now();
 	}
 
 	public static boolean isPRNotification(Notification notification) {
+		return notification.type.equals(NotificationType.PULL_REQ_ACC);
+	}
+
+	public static boolean isFollowNotification(Notification notification) {
 		return notification.type.equals(NotificationType.PULL_REQ_ACC);
 	}
 }

--- a/src/main/java/cos/peerna/domain/NotificationType.java
+++ b/src/main/java/cos/peerna/domain/NotificationType.java
@@ -4,7 +4,7 @@ package cos.peerna.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum NotificationType {
-	PULL_REQ, PULL_REQ_ACC, FRIEND, FRIEND_ACC, NORMAL;
+	PULL_REQ, PULL_REQ_ACC, FOLLOW, FOLLOW_EACH, NORMAL;
 
 	@JsonCreator
 	public static NotificationType from(String s) {

--- a/src/main/java/cos/peerna/domain/User.java
+++ b/src/main/java/cos/peerna/domain/User.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.LinkedList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,6 +33,11 @@ public class User {
     private Role role;
     @Embedded
     private Interest interests;
+
+    @OneToMany(mappedBy="followee", cascade=CascadeType.PERSIST)
+    private final List<Follow> followers = new LinkedList<>();
+    @OneToMany(mappedBy="follower", cascade=CascadeType.PERSIST)
+    private final List<Follow> followings = new LinkedList<>();
 
     public static User createUser(UserRegisterRequestDto dto) {
         User user = new User();

--- a/src/main/java/cos/peerna/repository/FollowRepository.java
+++ b/src/main/java/cos/peerna/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package cos.peerna.repository;
+
+import cos.peerna.domain.Follow;
+import cos.peerna.domain.History;
+import cos.peerna.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
+}

--- a/src/main/java/cos/peerna/repository/NotificationRepository.java
+++ b/src/main/java/cos/peerna/repository/NotificationRepository.java
@@ -13,6 +13,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	@Query("SELECT n FROM Notification n JOIN FETCH n.reply r JOIN FETCH r.problem p WHERE n.user = :user")
 	List<Notification> findByUser(User user);
 
+	List<Notification> findAllByUser(User user);
+
 	@Query("SELECT n FROM Notification n JOIN FETCH n.reply r JOIN FETCH r.problem p WHERE n.id = :id")
 	Notification findNotificationById(Long id);
 }

--- a/src/main/java/cos/peerna/service/NotificationService.java
+++ b/src/main/java/cos/peerna/service/NotificationService.java
@@ -82,7 +82,7 @@ public class NotificationService {
 					"PeerNA 자동 Pull-Request 입니다.");
 		}
 		if (Notification.isFollowNotification(notification)) {
-			userService.follow(sessionUser, notification.getFollower().getId());
+			userService.follow(sessionUser.getId(), notification.getFollower().getId());
 		}
 	}
 

--- a/src/main/java/cos/peerna/service/NotificationService.java
+++ b/src/main/java/cos/peerna/service/NotificationService.java
@@ -7,6 +7,7 @@ import cos.peerna.controller.dto.NotificationResponseDto;
 import cos.peerna.controller.dto.data.NotificationData;
 import cos.peerna.domain.Notification;
 import cos.peerna.domain.User;
+import cos.peerna.repository.FollowRepository;
 import cos.peerna.repository.NotificationRepository;
 import cos.peerna.repository.UserRepository;
 import cos.peerna.security.dto.SessionUser;
@@ -34,7 +35,7 @@ public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
 	private final UserRepository userRepository;
-
+	private final UserService userService;
 	private final RestTemplate restTemplate = new RestTemplate();
 
 	public NotificationResponseDto getNotifications(SessionUser sessionUser) {
@@ -44,6 +45,7 @@ public class NotificationService {
 
 		List<NotificationData> list = notificationList.stream().map(notification -> NotificationData.builder()
 				.notificationId(notification.getId())
+				.type(notification.getType().toString())
 				.answer(notification.getReply().getAnswer())
 				.msg(notification.getMsg())
 				.time(notification.getTime())
@@ -60,20 +62,27 @@ public class NotificationService {
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User Not Found"));
 		Notification notification = notificationRepository.findNotificationById(notificationId);
 
+		if (notification.getUser().getId().equals(user.getId())) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User Not Matched");
+		}
+
 		Notification.acceptNotification(notification);
 
-		String question = notification.getReply().getProblem().getQuestion();
-		String answer = notification.getReply().getAnswer();
-
-		String url = "https://api.github.com/repos/";
-		String repo = "backend-interview-question";
-
 		if (Notification.isPRNotification(notification)) {
+			String question = notification.getReply().getProblem().getQuestion();
+			String answer = notification.getReply().getAnswer();
+
+			String url = "https://api.github.com/repos/";
+			String repo = "backend-interview-question";
+
 			forkRepository(sessionUser.getToken(), url + "ksundong/backend-interview-question/forks");
 			createBranch(sessionUser, url, repo);
 			getContentAndPush(sessionUser, url + sessionUser.getLogin() + "/" + repo + "/", question, answer);
 			createPullReq(sessionUser, url + sessionUser.getLogin() + "/" + repo + "/pulls",
 					"PeerNA 자동 Pull-Request 입니다.");
+		}
+		if (Notification.isFollowNotification(notification)) {
+			userService.follow(sessionUser, notification.getFollower().getId());
 		}
 	}
 

--- a/src/main/java/cos/peerna/service/ReplyService.java
+++ b/src/main/java/cos/peerna/service/ReplyService.java
@@ -106,7 +106,12 @@ public class ReplyService {
         /* 좋아요가 일정 수 이상 넘어가면 자동으로 PR 요청 메시지 */
         if (!reply.isRequested() && reply.getLikeCount() == 10) {
             User likedUser = reply.getUser();
-            Notification notification = Notification.createNotification(likedUser, reply, NotificationType.PULL_REQ, "답변이 10개 이상이 되어 PR 요청을 보냈습니다.");
+            Notification notification = Notification.builder()
+                    .user(likedUser)
+                    .reply(reply)
+                    .type(NotificationType.PULL_REQ)
+                    .msg("답변이 10개 이상이 되어 PR 요청을 보냈습니다.")
+                    .build();
             notificationRepository.save(notification);
             Reply.requestReply(reply);
         }

--- a/src/main/java/cos/peerna/service/RoomService.java
+++ b/src/main/java/cos/peerna/service/RoomService.java
@@ -1,6 +1,6 @@
 package cos.peerna.service;
 
-import cos.peerna.controller.dto.MatchedUserDto;
+import cos.peerna.controller.dto.UserProfileDto;
 import cos.peerna.controller.dto.RoomResponseDto;
 import cos.peerna.domain.*;
 import cos.peerna.repository.*;
@@ -109,7 +109,7 @@ public class RoomService {
                                     .roomId(room.getId())
                                     .historyId(history.getId())
                                     .problem(history.getProblem())
-                                    .peer(new MatchedUserDto(peer))
+                                    .peer(new UserProfileDto(peer))
                                     .build()));
         }
     }
@@ -133,7 +133,7 @@ public class RoomService {
                                     .roomId(room.getId())
                                     .historyId(history.getId())
                                     .problem(history.getProblem())
-                                    .peer(new MatchedUserDto(peer))
+                                    .peer(new UserProfileDto(peer))
                                     .build()));
             return true;
         }
@@ -202,7 +202,7 @@ public class RoomService {
                                 .roomId(room.getId())
                                 .historyId(history.getId())
                                 .problem(history.getProblem())
-                                .peer(new MatchedUserDto(userRepository.findById(peer.getId()).orElse(null)))
+                                .peer(new UserProfileDto(userRepository.findById(peer.getId()).orElse(null)))
                                 .build()));
     }
     public void soloNext (SessionUser user, Integer roomId,
@@ -257,7 +257,7 @@ public class RoomService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "History Not Found"));
         Problem problem = history.getProblem();
         log.debug("loading problem: {}", problem.getQuestion());
-        MatchedUserDto matchedUserDto = null;
+        UserProfileDto userProfileDto = null;
 
         if (player == 2) {
             Long peerId = null;
@@ -269,14 +269,14 @@ public class RoomService {
             }
             User peer = userRepository.findById(peerId)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Peer Not Found"));
-            matchedUserDto = new MatchedUserDto(peer);
+            userProfileDto = new UserProfileDto(peer);
         }
 
         deferredResult.setResult(ResponseEntity.status(HttpStatus.CONFLICT).body(RoomResponseDto.builder()
                 .roomId(room.getId())
                 .historyId(history.getId())
                 .problem(problem)
-                .peer(matchedUserDto)
+                .peer(userProfileDto)
                 .build()));
         return true;
     }

--- a/src/main/java/cos/peerna/service/UserService.java
+++ b/src/main/java/cos/peerna/service/UserService.java
@@ -86,7 +86,6 @@ public class UserService {
         notificationRepository.save(Notification.builder()
                 .user(followee)
                 .msg(msg)
-                .reply(null)
                 .follower(follower)
                 .type(type)
                 .build());

--- a/src/main/java/cos/peerna/service/UserService.java
+++ b/src/main/java/cos/peerna/service/UserService.java
@@ -1,12 +1,11 @@
 package cos.peerna.service;
 
 import cos.peerna.controller.dto.UserPatchRequestDto;
-import cos.peerna.domain.Category;
-import cos.peerna.security.dto.SessionUser;
-import cos.peerna.domain.Career;
-import cos.peerna.domain.Interest;
-import cos.peerna.domain.User;
+import cos.peerna.domain.*;
+import cos.peerna.repository.FollowRepository;
+import cos.peerna.repository.NotificationRepository;
 import cos.peerna.repository.UserRepository;
+import cos.peerna.security.dto.SessionUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -25,6 +23,8 @@ import java.util.List;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final NotificationRepository notificationRepository;
 
     // 회원 가입
     public void join(User user) {
@@ -32,27 +32,18 @@ public class UserService {
     }
 
     public void delete(SessionUser sessionUser) {
-        User user = userRepository.findById(sessionUser.getId()).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User Not Found"));
+        User user = userRepository.findById(sessionUser.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User Not Found"));
         userRepository.delete(user);
     }
 
-    // 회원 전체 조회
     public List<User> findUsers() {
         return userRepository.findAll();
     }
 
-//    public Member findOne(Long memberId) {
-//        return memberRepository.findById(memberId);
-//    }
-
-    @Transactional
-    public void  updateCondition(SessionUser sessionUser, Interest interest, Career career) {
-        User user = userRepository.findById(sessionUser.getId()).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
-        user.updateCondition(interest, career);
-    }
-
     public void patchUpdate(SessionUser sessionUser, UserPatchRequestDto dto) {
-        User user = userRepository.findById(sessionUser.getId()).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+        User user = userRepository.findById(sessionUser.getId())
+                .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
         Interest interest = user.getInterests();
         Category priority1 = interest.getPriority1();
         Category priority2 = interest.getPriority2();
@@ -74,5 +65,48 @@ public class UserService {
 
         Interest newInterest = new Interest(priority1, priority2, priority3);
         user.updateCondition(newInterest, career);
+    }
+
+    public void follow(SessionUser sessionUser, Long followeeId) {
+        User follower = userRepository.findById(sessionUser.getId())
+                .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+        User followee =
+                userRepository.findById(followeeId).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+
+        validateFollow(follower, followee);
+        followRepository.save(new Follow(follower, followee));
+
+        String msg = follower.getName() + "님이 회원님을 팔로우하기 시작했습니다.";
+        NotificationType type = NotificationType.FOLLOW;
+        if (followRepository.findByFollowerAndFollowee(followee, follower).isPresent()) {
+            msg = follower.getName() + "님과 회원님이 서로를 팔로우하기 시작했습니다.";
+            type = NotificationType.FOLLOW_EACH;
+        }
+
+        notificationRepository.save(Notification.builder()
+                .user(followee)
+                .msg(msg)
+                .reply(null)
+                .follower(follower)
+                .type(type)
+                .build());
+    }
+
+    public void unfollow(SessionUser sessionUser, Long followeeId) {
+        User follower = userRepository.findById(sessionUser.getId())
+                .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+        User followee =
+                userRepository.findById(followeeId).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+        followRepository.delete(followRepository.findByFollowerAndFollowee(follower, followee)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT, "Already Not Followed")));
+    }
+
+    public void validateFollow(User follower, User followee) {
+        if (followee.equals(follower)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Can't Follow Self");
+        }
+        if (followRepository.findByFollowerAndFollowee(follower, followee).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already Followed");
+        }
     }
 }

--- a/src/main/java/cos/peerna/service/UserService.java
+++ b/src/main/java/cos/peerna/service/UserService.java
@@ -67,8 +67,8 @@ public class UserService {
         user.updateCondition(newInterest, career);
     }
 
-    public void follow(SessionUser sessionUser, Long followeeId) {
-        User follower = userRepository.findById(sessionUser.getId())
+    public void follow(Long followerId, Long followeeId) {
+        User follower = userRepository.findById(followerId)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
         User followee =
                 userRepository.findById(followeeId).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
@@ -91,8 +91,8 @@ public class UserService {
                 .build());
     }
 
-    public void unfollow(SessionUser sessionUser, Long followeeId) {
-        User follower = userRepository.findById(sessionUser.getId())
+    public void unfollow(Long followerId, Long followeeId) {
+        User follower = userRepository.findById(followerId)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
         User followee =
                 userRepository.findById(followeeId).orElseThrow(() -> new UsernameNotFoundException("User Not Found"));

--- a/src/main/java/cos/peerna/util/InitDB.java
+++ b/src/main/java/cos/peerna/util/InitDB.java
@@ -236,6 +236,13 @@ public class InitDB {
                     notificationRepository.save(notification);
                 }
             }
+            userService.follow(mincshin.getId(), happhee.getId());
+            userService.follow(happhee.getId(), mincshin.getId());
+            userService.follow(1L, happhee.getId());
+            userService.follow(happhee.getId(), 2L);
+            userService.follow(2L, happhee.getId());
+            userService.follow(3L, happhee.getId());
+
         }
     }
 }

--- a/src/main/java/cos/peerna/util/InitDB.java
+++ b/src/main/java/cos/peerna/util/InitDB.java
@@ -30,12 +30,12 @@ public class InitDB {
 
     @PostConstruct
     public void initDB() {
-//        initService.initRedis();
-//        initService.initDB();
-//        initService.initDB1(); // User, Problem
-//        initService.initDB2(); // Reply
-//        initService.initDB3(); // Happhee, Mincheol Shin
-//        initService.initDb4();
+        initService.initRedis();
+        initService.initDB();
+        initService.initDB1(); // User, Problem
+        initService.initDB2(); // Reply
+        initService.initDB3(); // Happhee, Mincheol Shin
+        initService.initDb4();
     }
 
     @Component

--- a/src/main/java/cos/peerna/util/InitDB.java
+++ b/src/main/java/cos/peerna/util/InitDB.java
@@ -12,8 +12,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisAccessor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -199,13 +197,13 @@ public class InitDB {
                 History history = historyService.createHistory(problem.getId(), room.getId());
 
                 replyService.make(ReplyRegisterRequestDto.builder()
-                        .answer(list.get(i-1))
+                        .answer(list.get(i - 1))
                         .problemId(problem.getId())
                         .historyId(history.getId())
                         .roomId(room.getId())
                         .build(), happhee.getId());
                 replyService.make(ReplyRegisterRequestDto.builder()
-                        .answer(list2.get(i-1))
+                        .answer(list2.get(i - 1))
                         .problemId(problem.getId())
                         .historyId(history.getId())
                         .roomId(room.getId())
@@ -218,13 +216,23 @@ public class InitDB {
         public void initDb4() {
             User happhee = em.find(User.class, (long) 79238676);
             User mincshin = em.find(User.class, (long) 48898994);
-            for(int i = 365; i < 393; i++) {
+            for (int i = 365; i < 393; i++) {
                 Reply reply = em.find(Reply.class, (long) i);
                 if (i % 2 == 0) {
-                    Notification notification = Notification.createNotification(mincshin, reply, NotificationType.PULL_REQ, "PR이 요청되었습니다." + i);
+                    Notification notification = Notification.builder()
+                            .user(mincshin)
+                            .reply(reply)
+                            .type(NotificationType.PULL_REQ)
+                            .msg("PR이 요청되었습니다." + i)
+                            .build();
                     notificationRepository.save(notification);
                 } else {
-                    Notification notification = Notification.createNotification(happhee, reply, NotificationType.PULL_REQ, "PR이 요청되었습니다." + i);
+                    Notification notification = Notification.builder()
+                            .user(happhee)
+                            .reply(reply)
+                            .type(NotificationType.PULL_REQ)
+                            .msg("PR이 요청되었습니다." + i)
+                            .build();
                     notificationRepository.save(notification);
                 }
             }

--- a/src/main/java/cos/peerna/util/InitDB.java
+++ b/src/main/java/cos/peerna/util/InitDB.java
@@ -242,6 +242,8 @@ public class InitDB {
             userService.follow(happhee.getId(), 2L);
             userService.follow(2L, happhee.getId());
             userService.follow(3L, happhee.getId());
+            userService.follow(2L, mincshin.getId());
+            userService.follow(3L, mincshin.getId());
 
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       initialize-schema: always
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## Motivation ⭐️

- 친구 추가 -> 팔로우로 선회
- 무조건 양방향 관계인 친구보다 단방향도 가능해지고, 추후에 기능 추가하기 쉬워짐
- 깃허브에서 팔로우 목록을 가져와서 추천해준다던가, 
- 우리 서비스에서 팔로우 하면 깃허브에서도 팔로우가 되는 등의 기능 확장에서 유리
- createNotification() 를 Builder 로 대체 -> 친구추가, pr 요청 구분 편리
- BaseTimeEntity 추가, 지금 이전 엔티티를 바꾸기는 무리지만
  한곤님 레포지토리 보다가 간단하고 좋아보여서 도입 (필요성=> **https://dkswnkk.tistory.com/542**)

<br>

## Key Changes 🔑

- @GetMapping("/oauth2-login-fail") 필요없는 매핑 삭제
- follow 기능 (+Follow Entity)
- unfollow 기능
- MatchedUserDto 는 유저프로필 정보를 담고 있어 다양한 곳에서 쓰일 수 있으므로 UserProfileDto 로 이름 변경
- createNotification() 를 Builder 로 대체 
- 


<br>

## To Reviewers 🙏

- initDB 에 initRedis() 는 주석처리를 안 하시는걸 권장합니다. redis-cli -> flushall 을 안해도 되게 만드는 함수
- DB 테이블 수정 및 추가되어서 ddl-auto 가 create 로 되어 있습니다. 첫 빌드만 이후에는 다시 none 으로 바꾸셔도 됩니다.
- 마찬가지로 첫 빌드 이후에는 initDB 다시 주석하셔도 됩니다. (initRedis 제외)

