### PR TITLE
#58 HTTP 권한 설정 및 웹소켓 attributes에 세션 사용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,4 @@ out/
 ### VS Code ###
 .vscode/
 
-src/main/generated/
-
 .DS_Store

--- a/src/main/java/cos/peerna/domain/room/dto/ChatMessageReceiveDto.java
+++ b/src/main/java/cos/peerna/domain/room/dto/ChatMessageReceiveDto.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 public class ChatMessageReceiveDto {
 
     private Integer roomId;
-    private Long writerId;
     private Long historyId;
     private String message;
 }

--- a/src/main/java/cos/peerna/domain/room/dto/ChatMessageSendDto.java
+++ b/src/main/java/cos/peerna/domain/room/dto/ChatMessageSendDto.java
@@ -1,6 +1,7 @@
 package cos.peerna.domain.room.dto;
 
 import cos.peerna.domain.room.model.Chat;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,15 +15,16 @@ public class ChatMessageSendDto {
     private String message;
     private LocalTime time;
 
-    public ChatMessageSendDto(ChatMessageReceiveDto receiveMessage) {
-        this.writerId = receiveMessage.getWriterId();
-        this.message = receiveMessage.getMessage();
-        this.time = LocalTime.now();
-    }
-
     public ChatMessageSendDto(Chat chat) {
         this.writerId = chat.getWriterId();
         this.message = chat.getContent();
         this.time = chat.getTime();
+    }
+
+    @Builder
+    public ChatMessageSendDto(Long writerId, String message) {
+        this.writerId = writerId;
+        this.message = message;
+        this.time = LocalTime.now();
     }
 }

--- a/src/main/java/cos/peerna/domain/user/model/Role.java
+++ b/src/main/java/cos/peerna/domain/user/model/Role.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    ADMIN("ROLE_ADMIN", "관리자"),
-    MENTOR("ROLE_MENTOR", "멘토"),
-    MENTEE("ROLE_MENTEE", "멘티");
+    ANONYMOUS("ANONYMOUS", "익명"),
+    USER("USER", "유저"),
+    ADMIN("ADMIN", "관리자");
 
     private final String key;
     private final String title;

--- a/src/main/java/cos/peerna/global/config/SecurityConfig.java
+++ b/src/main/java/cos/peerna/global/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor
-@EnableWebSecurity // spring security 설정들을 활성화시켜준다.
+@EnableWebSecurity
 @Configuration
 public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
@@ -18,36 +18,22 @@ public class SecurityConfig {
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
-
-
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        /**
-         * 주의: 생각보다 순서가 굉장히 중요하다.
-         */
-//        http.authorizeHttpRequests().anyRequest().permitAll();
 
-//        http
-//                .headers()
-//                .httpStrictTransportSecurity()
-//                .maxAgeInSeconds(31536000)
-//                .includeSubDomains(true)
-//                .preload(true);
-//        http
-//                .authorizeHttpRequests()
-//                .requestMatchers("/oauth2/**", "/login").anonymous()
-//                .anyRequest().permitAll();
+        http
+                .authorizeHttpRequests()
+                .requestMatchers("/api/**").hasAnyAuthority("USER")
+                .anyRequest().permitAll();
         http
                 .csrf()
-                    .disable()
-//                .httpBasic()
-//                    .disable()
+                .disable();
+        http
                 .oauth2Login()
                 .successHandler(customAuthenticationSuccessHandler)
                 .failureHandler(customAuthenticationFailureHandler)
                 .userInfoEndpoint()
-                    .userService(customOAuth2UserService);
+                .userService(customOAuth2UserService);
         http
                 .httpBasic();
         http
@@ -61,98 +47,32 @@ public class SecurityConfig {
                 .logoutUrl("/logout")
                 .invalidateHttpSession(true)
                 .deleteCookies("SESSION");
-//                .logoutSuccessHandler((request, response, authentication) -> {
-////                    response.sendRedirect("http://localhost:3000/callback?logout=success");
-////                    response.sendRedirect("http://peerna.kr/callback?logout=success");
-//                });
-//        http.logout()
-//                .logoutUrl("/logout")
-//                .logoutSuccessUrl("/login?logout")
-//                .invalidateHttpSession(true)
-//                .deleteCookies("JSESSIONID")
-//                .permitAll();
 
         http
                 .authenticationProvider(customAuthenticationProvider)
-                    .exceptionHandling()
-                        .authenticationEntryPoint(customAuthenticationEntryPoint);
+                .exceptionHandling()
+                .authenticationEntryPoint(customAuthenticationEntryPoint);
 
 
 
-//        http
-//                .sessionManagement()
-//                .maximumSessions(1)
-//                .maxSessionsPreventsLogin(true);
+        http
+                .sessionManagement()
+                .maximumSessions(1)
+                .maxSessionsPreventsLogin(true);
 
         return http.build();
     }
-
-
-//                .and()
-//                .logout()
-//                .logoutUrl("/logout")
-//                .logoutSuccessHandler((request, response, authentication) -> {
-//                    response.sendRedirect("/");
-//                })
-
-//        http
-//                .headers().frameOptions().disable();
-
-
-
-//    @Bean
-//    public CorsConfigurationSource corsConfigurationSource() {
-//        CorsConfiguration configuration = new CorsConfiguration();
-//        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-//        configuration.setAllowedMethods(Arrays.asList("*"));
-//        configuration.addAllowedHeader("*");
-//        configuration.setAllowCredentials(true);
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        source.registerCorsConfiguration("/**", configuration);
-//        return source;
-//    }
-
 }
-/**
- * csrf().disable() 하는 이유
- * 추후에 없앨 가능성 높음
- * https://velog.io/@woohobi/Spring-security-csrf%EB%9E%80
- * <p>
- * .maximumSessions(1)
- * 최대 허용 가능 세션 수, 5 하면 넷플릭스 마냥 5개 허용?
- * <p>
- * .maxSessionsPreventsLogin(true); 동시로그인 설정
+
+/*
+ * .maxSessionsPreventsLogin();
  * true -> 동일한 계정으로 먼저 접근한 회원이 있다면 두 번째로 접근한 회원은 접근 불가능
- * false -> 반대로 동일한 계정으로 먼저 접근한 회원이 있고,
- * 두 번째 회원이 접근하면 첫 번째 회원의 세션을 만료시키고 두 번째 회원의 세션을 정상 로그인처리
- * <p>
- * .oauth2Login()
- * OAuth 2 로그인 기능에 대한 여러 설정의 진입점이다.
- * <p>
+ * false -> 먼저 로그인한 계정을 로그아웃 시키고 접근
+
  * .userInfoEndpoint()
  * OAuth 2 로그인 성공 이후 사용자 정보를 가져올 떄의 설정들을 담당한다.
- * <p>
+
  * .userService(customOAuth2UserService);
  * 소셜 로그인 성공시 후속 조치를 진행할 UserService 인터페이스의 구현체를 등록한다.
  * 리소스 서버(소셜 서비스들)에서 사용자 정보를 가져온 상태에서 추가로 진행하고자하는 기능을 명시할 수 있다.
- * <p>
- * <p>
- * <p>
- * .authorizeRequests()
- * URL별 권한 관리를 설정하는 옵션의 시작점이다. authorizeRequests()가 선언되어야만 antMatchers 옵션을 사용할 수 있다.
- * <p>
- * .antMatchers()
- * 권한 관리 대상을 지정하는 옵션이다.
- * URL, HTTP 메소드별로 관리가 가능하다. 지정된 URL들은 permitAll() 옵션을 통해 전체 열람 관한을 준다.
- * .antMatchers("/","/css/**","/images/**","/js/**","/h2-console?**").permitAll()
- * <p>
- * .antMatchers("/api/v1/**").hasRole(Role.USER.name())
- * "/api/v1/**" 주소를 가진 API는 USER 권한을 가진 사람만 가능하도록 한다.
- * <p>
- * .anyRequest().authenticated()
- * 설정된 값 이외의 나머지 URL들을 나타낸다. authenticated()를 추가하여
- * 나머지 URL들은 모두 인증된 사용자들(로그인한 사용자들)에게만 허용한다.
- * <p>
- * .logout().logoutSuccessUrl("/")
- * 로그아웃 기능에 대한 여러 설정의 진입점이다. 로그아웃 성공시 "/" 주소로 이동한다.
  **/

--- a/src/main/java/cos/peerna/global/config/WebSocketBrokerConfig.java
+++ b/src/main/java/cos/peerna/global/config/WebSocketBrokerConfig.java
@@ -1,5 +1,6 @@
 package cos.peerna.global.config;
 
+import cos.peerna.global.security.HttpHandshakeInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -9,24 +10,20 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
-
-    // endpoint를 /stomp로 하고, allowedOrigins를 "*"로 하면 페이지에서
-    // Get /info 404 Error가 발생한다. 그래서 아래와 같이 2개의 계층으로 분리하고
-    // origins를 개발 도메인으로 변경하니 잘 동작하였다.
-    //이유는 왜 그런지 아직 찾지 못함
     @Override
-    public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/stomp/chat")
+    public void registerStompEndpoints(StompEndpointRegistry stompEndpointRegistry) {
+        stompEndpointRegistry.addEndpoint("stomp")
+                .addInterceptors(new HttpHandshakeInterceptor())
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 
-    /*어플리케이션 내부에서 사용할 path를 지정할 수 있음*/
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // /pub 경로로 시작하는 STOMP 메세지의 "destination" 헤더는
-        // @Controller 객체의 @MessageMapping 메서드로 라우팅된다.
-        registry.setApplicationDestinationPrefixes("/pub");
-        registry.enableSimpleBroker("/sub");
+        // MessageMapping 요청의 prefix
+        registry.setApplicationDestinationPrefixes("/app");
+
+        // subscribe 요청의 prefix
+        registry.enableSimpleBroker("/chat", "/match");
     }
 }

--- a/src/main/java/cos/peerna/global/security/HttpHandshakeInterceptor.java
+++ b/src/main/java/cos/peerna/global/security/HttpHandshakeInterceptor.java
@@ -1,0 +1,32 @@
+package cos.peerna.global.security;
+
+import cos.peerna.global.security.dto.SessionUser;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+public class HttpHandshakeInterceptor implements HandshakeInterceptor {
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpSession session = servletRequest.getServletRequest().getSession();
+            SessionUser user = (SessionUser) session.getAttribute("user");
+            if (user == null) {
+                return false;
+            }
+            attributes.put("user", session.getAttribute("user"));
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/src/main/java/cos/peerna/global/security/dto/SessionUser.java
+++ b/src/main/java/cos/peerna/global/security/dto/SessionUser.java
@@ -1,15 +1,16 @@
 package cos.peerna.global.security.dto;
 
-import cos.peerna.domain.user.model.Career;
-import cos.peerna.domain.user.model.Interest;
+import cos.peerna.domain.user.model.Category;
 import cos.peerna.domain.user.model.User;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 
 @Getter
+@ToString
 public class SessionUser implements UserDetails {
     private Long id;
     private String name;
@@ -43,7 +44,7 @@ public class SessionUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return null;
+        return id.toString();
     }
 
     @Override


### PR DESCRIPTION
## Motivation ⭐️

- feat: HTTP 세션을 웹소켓에서도 사용
- feat: HTTP API 권한 설정

<br>

## Key Changes 🔑

- StompEndpointRegistry 에 인터셉터 추가를 통해 웹소켓에서도 세션 사용
- Controller에 있는 로그인 검사로직 삭제
- ("/api/**") 경로의 request 들이 모두 Role.USER 를 가져야함


<br>

## To Reviewers 🙏

- 

