### PR TITLE
feat: 동료 매칭 디벨롭 [#57, #59]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 build/
 src/main/generated/
+src/main/frontend/node_modules/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -6,7 +6,7 @@
     "build": "tailwindcss -i ./main.css -o ../resources/static/main.css"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.1"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.0.0",

--- a/src/main/java/cos/peerna/PeernaApplication.java
+++ b/src/main/java/cos/peerna/PeernaApplication.java
@@ -7,8 +7,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+@EnableAsync
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"cos.peerna"})
 @EnableRedisRepositories

--- a/src/main/java/cos/peerna/domain/match/controller/MatchController.java
+++ b/src/main/java/cos/peerna/domain/match/controller/MatchController.java
@@ -16,17 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class MatchController {
+
     private final MatchService matchService;
+
     @MessageMapping("/match/join")
     @SendToUser("/match/join")
     public ResponseEntity<String> joinQueue(SimpMessageHeaderAccessor messageHeaderAccessor, String category) {
         SessionUser user = (SessionUser) messageHeaderAccessor.getSessionAttributes().get("user");
 
-        Standby standby =  matchService.addStandby(Standby.builder()
-                .id(user.getId())
-                .score(user.getScore())
-                .createdAt(LocalDateTime.now())
-                .build(), Category.valueOf(category));
+        Standby standby =  matchService.addStandby(user, Category.valueOf(category));
         if (standby == null) {
             return new ResponseEntity<>("already exist", HttpStatus.CONFLICT);
         }

--- a/src/main/java/cos/peerna/domain/match/controller/MatchController.java
+++ b/src/main/java/cos/peerna/domain/match/controller/MatchController.java
@@ -1,0 +1,35 @@
+package cos.peerna.domain.match.controller;
+
+import cos.peerna.domain.match.model.Standby;
+import cos.peerna.domain.match.service.MatchService;
+import cos.peerna.domain.user.model.Category;
+import cos.peerna.global.security.dto.SessionUser;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MatchController {
+    private final MatchService matchService;
+    @MessageMapping("/match/join")
+    @SendToUser("/match/join")
+    public ResponseEntity<String> joinQueue(SimpMessageHeaderAccessor messageHeaderAccessor, String category) {
+        SessionUser user = (SessionUser) messageHeaderAccessor.getSessionAttributes().get("user");
+
+        Standby standby =  matchService.addStandby(Standby.builder()
+                .id(user.getId())
+                .score(user.getScore())
+                .createdAt(LocalDateTime.now())
+                .build(), Category.valueOf(category));
+        if (standby == null) {
+            return new ResponseEntity<>("already exist", HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>("success", HttpStatus.OK);
+    }
+}

--- a/src/main/java/cos/peerna/domain/match/job/MatchJob.java
+++ b/src/main/java/cos/peerna/domain/match/job/MatchJob.java
@@ -1,0 +1,36 @@
+package cos.peerna.domain.match.job;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import cos.peerna.domain.match.service.MatchService;
+import cos.peerna.domain.user.model.Category;
+import lombok.RequiredArgsConstructor;
+import org.quartz.InterruptableJob;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.UnableToInterruptJobException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchJob extends QuartzJobBean implements InterruptableJob {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MatchService matchService;
+
+    @Override
+    public void interrupt() throws UnableToInterruptJobException {
+    }
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        for (Category category : Category.values()) {
+            try {
+                matchService.duoMatching(category);
+            } catch (JsonProcessingException e) {
+                redisTemplate.delete("standby:" + category.name());
+            }
+        }
+    }
+}

--- a/src/main/java/cos/peerna/domain/match/model/Standby.java
+++ b/src/main/java/cos/peerna/domain/match/model/Standby.java
@@ -1,0 +1,27 @@
+package cos.peerna.domain.match.model;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Standby {
+
+    private final Long id;
+    private final Integer score;
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public Standby(Long id, Integer score, LocalDateTime createdAt) {
+        this.id = id;
+        this.score = score;
+        this.createdAt = createdAt;
+    }
+
+    public boolean isMatchable(Standby standby) {
+        long waitingTime = ChronoUnit.SECONDS.between(this.createdAt, LocalDateTime.now());
+        int scoreGap = Math.abs(this.score - standby.score);
+        return scoreGap <= 50 + Math.log(1 + waitingTime) / Math.log(2);
+    }
+}

--- a/src/main/java/cos/peerna/domain/match/service/MatchService.java
+++ b/src/main/java/cos/peerna/domain/match/service/MatchService.java
@@ -81,6 +81,9 @@ public class MatchService {
                     redisTemplate.opsForZSet().remove("standby:" + category.name(), objectMapper.writeValueAsString(target));
                     template.convertAndSend("/user/" + standby.getId() + "/match/join", "successJOIN");
                     template.convertAndSend("/user/" + target.getId() + "/match/join", "successJOIN");
+                    /*
+                     * TODO: Room 생성 이벤트 발생
+                     */
                     break;
                 }
             }

--- a/src/main/java/cos/peerna/domain/match/service/MatchService.java
+++ b/src/main/java/cos/peerna/domain/match/service/MatchService.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cos.peerna.domain.match.job.MatchJob;
 import cos.peerna.domain.match.model.Standby;
 import cos.peerna.domain.user.model.Category;
+import cos.peerna.global.security.dto.SessionUser;
 import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +52,13 @@ public class MatchService {
         }
     }
 
-    public Standby addStandby(Standby standby, Category category) {
+    public Standby addStandby(SessionUser user, Category category) {
+        Standby standby = Standby.builder()
+                .id(user.getId())
+                .score(user.getScore())
+                .createdAt(LocalDateTime.now())
+                .build();
+
         try {
             String json = objectMapper.writeValueAsString(standby);
             double score = standby.getScore().doubleValue();

--- a/src/main/java/cos/peerna/domain/match/service/MatchService.java
+++ b/src/main/java/cos/peerna/domain/match/service/MatchService.java
@@ -1,0 +1,117 @@
+package cos.peerna.domain.match.service;
+
+import static org.quartz.JobBuilder.newJob;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cos.peerna.domain.match.job.MatchJob;
+import cos.peerna.domain.match.model.Standby;
+import cos.peerna.domain.user.model.Category;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+    private static final Class JOB_CLASS = MatchJob.class;
+    private static final String DEVELOPER_NAME = "송승훈";
+    private static final String JOB_DESCRIPTION = "동료 매칭";
+    private static final String SCHEDULE_EXPRESSION = "*/5 * * * * ?";
+    private static final String JOB_IDENTITY = "Dev";
+    private static final String JOB_WORK = "Work";
+    private final Scheduler scheduler;
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final SimpMessagingTemplate template;
+
+    @PostConstruct
+    public void scheduleJob() {
+        JobDetail jobDetail = buildJobDetail(JOB_CLASS, DEVELOPER_NAME, JOB_DESCRIPTION);
+        try {
+            scheduler.scheduleJob(jobDetail, buildJobTrigger(SCHEDULE_EXPRESSION));
+        } catch (SchedulerException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    public Standby addStandby(Standby standby, Category category) {
+        try {
+            String json = objectMapper.writeValueAsString(standby);
+            double score = standby.getScore().doubleValue();
+            redisTemplate.opsForZSet().add("standby:" + category, json, score);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            return null;
+        }
+        return standby;
+    }
+
+    @Async
+    public void duoMatching(Category category) throws JsonProcessingException {
+        List<Standby> standbyList = findStandby(category);
+        if (standbyList.size() < 2) {
+            return;
+        }
+        while (standbyList.size() >= 2) {
+            Standby standby = standbyList.remove(0);
+            for (int i = 0; i < standbyList.size(); i++) {
+                Standby target = standbyList.get(i);
+                if (!standby.isMatchable(target))
+                    break;
+                if (target.isMatchable(standby)) {
+                    log.debug("[" + standby.getId() + "] and [" + target.getId() + "] are matched!");
+                    standbyList.remove(i);
+                    redisTemplate.opsForZSet().remove("standby:" + category.name(), objectMapper.writeValueAsString(standby));
+                    redisTemplate.opsForZSet().remove("standby:" + category.name(), objectMapper.writeValueAsString(target));
+                    template.convertAndSend("/user/" + standby.getId() + "/match/join", "successJOIN");
+                    template.convertAndSend("/user/" + target.getId() + "/match/join", "successJOIN");
+                    break;
+                }
+            }
+        }
+    }
+
+    private Trigger buildJobTrigger(String scheduleExp) {
+        return TriggerBuilder.newTrigger()
+                .withSchedule(CronScheduleBuilder.cronSchedule(scheduleExp)).build();
+    }
+
+    private JobDetail buildJobDetail(Class job, String name, String work) {
+        return newJob(job).withIdentity("scheduleJob")
+                .usingJobData(newJobDataMap(name, work))
+                .build();
+    }
+
+    private JobDataMap newJobDataMap(String name, String work) {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put(JOB_IDENTITY, name);
+        jobDataMap.put(JOB_WORK, work);
+        return jobDataMap;
+    }
+
+    private List<Standby> findStandby(Category category) throws JsonProcessingException {
+        Set<String> standbyStrSet = redisTemplate.opsForZSet().range("standby:" + category.name(), 0, -1);
+        List<Standby> standbyList = new ArrayList<>();
+        for (String standbyStr : standbyStrSet) {
+            Standby standby = objectMapper.readValue(standbyStr, Standby.class);
+            standbyList.add(standby);
+        }
+        return standbyList;
+    }
+}

--- a/src/main/java/cos/peerna/domain/user/service/UserService.java
+++ b/src/main/java/cos/peerna/domain/user/service/UserService.java
@@ -38,7 +38,7 @@ public class UserService {
                 .email(dto.getEmail())
                 .imageUrl("https://avatars.githubusercontent.com/u/0?v=4")
                 .introduce("")
-                .role(Role.MENTEE)
+                .role(Role.USER)
                 .build());
         return user.getId();
     }

--- a/src/main/java/cos/peerna/global/common/controller/HomeController.java
+++ b/src/main/java/cos/peerna/global/common/controller/HomeController.java
@@ -32,7 +32,6 @@ public class HomeController {
         if (user == null) {
             return "login";
         }
-        log.debug("user: {}", user);
         model.addAttribute("userId", user.getId());
         model.addAttribute("userName", user.getName());
         model.addAttribute("userImage", user.getImageUrl());

--- a/src/main/java/cos/peerna/global/common/controller/HomeController.java
+++ b/src/main/java/cos/peerna/global/common/controller/HomeController.java
@@ -27,11 +27,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class HomeController {
     private final UserRepository userRepository;
 
-    @GetMapping
+    @GetMapping("/")
     public String index(@Nullable @LoginUser SessionUser user, Model model) {
         if (user == null) {
             return "login";
         }
+        log.debug("user: {}", user);
         model.addAttribute("userId", user.getId());
         model.addAttribute("userName", user.getName());
         model.addAttribute("userImage", user.getImageUrl());

--- a/src/main/java/cos/peerna/global/config/SecurityConfig.java
+++ b/src/main/java/cos/peerna/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import cos.peerna.global.security.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,6 +24,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests()
+                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                 .requestMatchers("/api/**").hasAnyAuthority("USER")
                 .anyRequest().permitAll();
         http

--- a/src/main/java/cos/peerna/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/cos/peerna/global/security/CustomOAuth2UserService.java
@@ -99,7 +99,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                         .email(attributes.getEmail())
                         .imageUrl(attributes.getImageUrl())
                         .introduce(attributes.getBio())
-                        .role(Role.MENTEE)
+                        .role(Role.USER)
                         .build());
         return userRepository.save(user);
     }

--- a/src/main/resources/static/js/match.js
+++ b/src/main/resources/static/js/match.js
@@ -26,16 +26,7 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 function joinQueue() {
-    let category = document.getElementById("priority1").value;
-    // if (category === 'OPERATING_SYSTEM')
-    //     category = 1;
-    // if (category === 'NETWORK')
-    //     category = 2;
-    // if (category === 'DATABASE')
-    //     category = 3;
-    // stompClient.send("/app/match/join", {}, JSON.stringify(category), function (error) {
-    //     console.log('error', error);
-    // });
+    let category = document.getElementById("category").value;
     stompClient.send("/app/match/join", {}, category, function (error) {
         console.log('error', error);
     });

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -39,29 +39,10 @@
     </header>
     <main class="bg-[#f0f0f0] p-8 flex">
         <div class="w-1/5 pr-4">
-            <h2 class="text-[#333333] text-2xl font-bold mb-4">학습 카테고리 선택</h2>
             <div class="mb-8">
-                <label for="priority1"
-                       class="my-2 block mb-2 text-xl font-medium text-gray-900 dark:text-white">1순위</label>
-                <select id="priority1" name="priority1"
-                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                    <option selected>카테고리 선택</option>
-                    <option value="OPERATING_SYSTEM">운영체제</option>
-                    <option value="NETWORK">네트워크</option>
-                    <option value="DATA_STRUCTURE_ALGORITHM">자료구조</option>
-                </select>
-                <label for="priority2"
-                       class="my-2 block mb-2 text-xl font-medium text-gray-900 dark:text-white">2순위</label>
-                <select id="priority2" name="priority2"
-                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                    <option selected>카테고리 선택</option>
-                    <option value="OPERATING_SYSTEM">운영체제</option>
-                    <option value="NETWORK">네트워크</option>
-                    <option value="DATA_STRUCTURE_ALGORITHM">자료구조</option>
-                </select>
-                <label for="priority3"
-                       class="my-2 block mb-2 text-xl font-medium text-gray-900 dark:text-white">3순위</label>
-                <select id="priority3" name="priority3"
+                <label for="category"
+                       class="my-2 block mb-2 text-xl font-medium text-gray-900 dark:text-white">학습 카테고리 선택</label>
+                <select id="category" name="category"
                         class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
                     <option selected>카테고리 선택</option>
                     <option value="OPERATING_SYSTEM">운영체제</option>


### PR DESCRIPTION
# 동료매칭

## 기존구현

1. 유저마다 우선순위 1, 2, 3 순위 를 입력받아서 새로운 유저가 들어올 때마다 높은 우선순위부터 매칭한다
    - 모든 유저가 같은 큐에 존재
    - 작업을 나누어서 병행처리를 하려 할 때, Transaction 레벨이 serializable 하게 될 것
    - 대기시간, 우선순위 등 형평성 있는 매칭을 진행하기에 알고리즘이 매우 까다로움
2. 카테고리의 개수가 25개로 선택지가 많다.
3. 유저의 Career 를 바탕으로 매칭

## 디벨롭 내용

1. 우선순위없이 1개의 Category를 선택한다.
    1. 카테고리별로 매칭 대기 큐를 만든다.
    2. 매칭 작업을 병행으로 처리한다.
    3. 유저 하나가 다수의 카테고리를 갖지 않으므로 Interest를 삭제한다.
2. 카테고리의 수를 6개 (***DATA_STRUCTURE_ALGORITHM***, ***OPERATING_SYSTEM***, ***NETWORK***, ***DATABASE***, ***SECURITY***, ***Personality)**로 줄인다.*
    1. 아래와 같은 카테고리도 추가할 수 있을 것 같음
        1. **RANDOM**, 랜덤으로 다른 카테고리로 선택되는 것 (기다리는 사람이 홀수인 카테고리로 들어간다거나)
        2. **PRACTICE**, 실전처럼 모든 카테고리의 질문이 나오는 것
3. 유저의 score를 바탕으로 매칭한다.
    1. Career 삭제